### PR TITLE
Opt-in pour s'afficher sur Pamela

### DIFF
--- a/space/serializers.py
+++ b/space/serializers.py
@@ -9,6 +9,7 @@ class PamelaSerializer(serializers.Serializer):
     unknown_mac = serializers.ListField(serializers.CharField())
     age = serializers.IntegerField()
     users = UserSerializer(many=True)
+    hidden = serializers.IntegerField()
 
 
 class SpaceStatusSerializer(serializers.ModelSerializer):

--- a/space/templates/pamela.html
+++ b/space/templates/pamela.html
@@ -96,6 +96,12 @@ var PamelaNoobsBox = React.createClass({
 
 var Pamela = React.createClass({
     pamela_content: function(){
+        var hidden_text = "";
+        if (this.state.hidden > 1){
+            hidden_text = "Et " + this.state.hidden + " autres personnes";
+        } else if (this.state.hidden > 0){
+            hidden_text = "Et 1 autre personne";
+        }
         if (this.state.unknown_mac.length + this.state.users.length == 0){
             return <div className="col-md-12 col-sm-12">
                 <h2>Il n'y a personne au Hackerspace pour l'instant</h2>
@@ -109,13 +115,16 @@ var Pamela = React.createClass({
                 <div className="col-md-6 col-sm-12">
                     <h3>Inconnus</h3>
                     <PamelaNoobsBox macs={this.state.unknown_mac}/>
+                    <h4>{hidden_text}</h4>
                 </div>
             </div>;
 
         }
     },
     render: function(){
+        var total_macs = this.state.users.length + this.state.unknown_mac.length + this.state.hidden;
         return <div className="container-fluid">
+            <h3><small>Nous sommes <strong>{total_macs}</strong> pour le moment</small></h3>
             {this.pamela_content()}
             <div className="row-fluid">
                 <h2 className="col-sm-12">

--- a/space/templates/pamela.html
+++ b/space/templates/pamela.html
@@ -41,6 +41,19 @@ PAMELA
                 {% bootstrap_form form %}
                 {% buttons %}
                 <button type="submit" class="btn btn-info">Ajouter à Pamela</button>
+                {% if user.hide_pamela %}
+                    <abbr title="Vous n'apparaissez actuellement pas sur ce site lorsque vous êtes sur le réseau de UrLab.">
+                        <a href="{% url "show_pamela" %}" class="btn btn-primary pull-right">
+                                Apparaître
+                        </a>
+                    </abbr></td>
+                {% else %}
+                    <abbr title="Votre pseudonyme apparaît sur ce site lorsque vous êtes sur le réseau de UrLab.">
+                        <a href="{% url "hide_pamela" %}" class="btn btn-warning pull-right">
+                            Disparaître
+                        </a>
+                    </abbr>
+                {% endif %}
                 {% endbuttons %}
             </form>
             <p class="text-muted"><small>

--- a/space/views.py
+++ b/space/views.py
@@ -22,20 +22,22 @@ from .decorators import private_api, one_or_zero
 from incubator.settings import (INFLUX_HOST, INFLUX_PORT, INFLUX_USER,
                                 INFLUX_PASS)
 
+
 def make_pamela():
     redis = get_redis()
     updated, maclist = get_mac(redis)
 
     known_mac = MacAdress.objects.filter(adress__in=maclist)
     users = {mac.holder for mac in known_mac if mac.holder is not None}
-
+    visible_users = {u for u in users if not u.hide_pamela}
     unknown_mac = list(filter(lambda x: x not in [obj.adress for obj in known_mac], maclist))
 
     return {
         'raw_maclist': maclist,
         'updated': updated,
         'unknown_mac': ['xx:xx:xx:xx:' + mac[-5:] for mac in unknown_mac],
-        'users': users,
+        'users': visible_users,
+        'hidden': len(users) - len(visible_users),
     }
 
 
@@ -104,11 +106,11 @@ def spaceapi(request):
 
     if len(names) == 0:
         people_now_present = {
-            "value": 0,
+            "value": pam['hidden'],
         }
     else:
         people_now_present = {
-            "value": len(names),
+            "value": len(names) + pam['hidden'],
             "names": names,
         }
 

--- a/space/views.py
+++ b/space/views.py
@@ -190,6 +190,7 @@ class PamelaObject(object):
         self.age = pamela_dict['updated']
         self.unknown_mac = pamela_dict['unknown_mac']
         self.users = pamela_dict['users']
+        self.hidden = pamela_dict['hidden']
 
 
 class PamelaViewSet(viewsets.ViewSet):

--- a/users/migrations/0002_user_hide_pamela.py
+++ b/users/migrations/0002_user_hide_pamela.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0001_squashed_0009_user_is_active'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='hide_pamela',
+            field=models.BooleanField(default=True, verbose_name='caché sur pamela'),
+        ),
+    ]

--- a/users/models.py
+++ b/users/models.py
@@ -57,6 +57,8 @@ class User(AbstractBaseUser):
     balance = models.DecimalField(max_digits=6, decimal_places=2, default=0, verbose_name="ardoise")
     has_key = models.BooleanField(default=False, verbose_name="possède une clé")
 
+    hide_pamela = models.BooleanField(default=True, verbose_name='caché sur pamela')
+
     # Needed for compatibility with the Django build-in User model
     groups = models.ManyToManyField(Group, blank=True)
     is_active = models.BooleanField(default=True)

--- a/users/templates/user_detail.html
+++ b/users/templates/user_detail.html
@@ -80,6 +80,27 @@ Profil de {{user.username}}
             <br>
             <h4>Vos adresses MAC</h4>
             <table class="table table-condensed">
+            {% if user.hide_pamela %}
+                <tr>
+                    <td>Vous êtes caché sur P.A.M.E.L.A</td>
+                    <td>
+                        <a href="{% url "show_pamela" %}" class="btn btn-primary">
+                            Apparaître
+                        </a>
+                    </td>
+                    <td></td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td>Vous apparaissez sur P.A.M.E.L.A</td>
+                    <td>
+                        <a href="{% url "hide_pamela" %}" class="btn btn-warning">
+                            Disparaître
+                        </a>
+                    </td>
+                    <td></td>
+                </tr>
+            {% endif %}
             {% for mac in user.macadress_set.all %}
                 <tr>
                     <td>{{mac.machine_name}}</td>

--- a/users/templates/user_detail.html
+++ b/users/templates/user_detail.html
@@ -82,7 +82,7 @@ Profil de {{user.username}}
             <table class="table table-condensed">
             {% if user.hide_pamela %}
                 <tr>
-                    <td>Vous êtes caché sur P.A.M.E.L.A</td>
+                    <td>Vous êtes caché sur <a href="{% url "pamela_list" %}">P.A.M.E.L.A</a></td>
                     <td><abbr title="Vous n'apparaissez actuellement pas sur ce site lorsque vous êtes sur le réseau de UrLab.">
                         <a href="{% url "show_pamela" %}" class="btn btn-primary">
                             Apparaître
@@ -92,7 +92,7 @@ Profil de {{user.username}}
                 </tr>
             {% else %}
                 <tr>
-                    <td>Vous apparaissez sur P.A.M.E.L.A</td>
+                    <td>Vous apparaissez sur <a href="{% url "pamela_list" %}">P.A.M.E.L.A</a></td>
                     <td><abbr title="Votre pseudonyme apparaît sur ce site lorsque vous êtes sur le réseau de UrLab.">
                         <a href="{% url "hide_pamela" %}" class="btn btn-warning">
                             Disparaître

--- a/users/templates/user_detail.html
+++ b/users/templates/user_detail.html
@@ -83,21 +83,21 @@ Profil de {{user.username}}
             {% if user.hide_pamela %}
                 <tr>
                     <td>Vous êtes caché sur P.A.M.E.L.A</td>
-                    <td>
+                    <td><abbr title="Vous n'apparaissez actuellement pas sur ce site lorsque vous êtes sur le réseau de UrLab.">
                         <a href="{% url "show_pamela" %}" class="btn btn-primary">
                             Apparaître
                         </a>
-                    </td>
+                    </abbr></td>
                     <td></td>
                 </tr>
             {% else %}
                 <tr>
                     <td>Vous apparaissez sur P.A.M.E.L.A</td>
-                    <td>
+                    <td><abbr title="Votre pseudonyme apparaît sur ce site lorsque vous êtes sur le réseau de UrLab.">
                         <a href="{% url "hide_pamela" %}" class="btn btn-warning">
                             Disparaître
                         </a>
-                    </td>
+                    </abbr></td>
                     <td></td>
                 </tr>
             {% endif %}

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
 from django.contrib.auth.decorators import login_required
-from .views import CurrentUserDetailView, balance, UserDetailView, UserEditView, spend, top
+from .views import CurrentUserDetailView, balance, UserDetailView, UserEditView, spend, top, show_pamela, hide_pamela
 
 urlpatterns = patterns(
     '',
@@ -9,5 +9,7 @@ urlpatterns = patterns(
     url(r'^balance$', login_required(balance), name='change_balance'),
     url(r'^balance/spend', login_required(spend), name='balance_spend'),
     url(r'^balance/top', login_required(top), name='balance_top'),
+    url(r'^show_pamela', login_required(show_pamela), name='show_pamela'),
+    url(r'^hide_pamela', login_required(hide_pamela), name='hide_pamela'),
     url(r'^(?P<slug>.+)', UserDetailView.as_view(), name='user_profile'),
 )

--- a/users/views.py
+++ b/users/views.py
@@ -49,6 +49,18 @@ def top(request):
     return HttpResponseRedirect(reverse('change_balance'))
 
 
+def show_pamela(request):
+    request.user.hide_pamela = False
+    request.user.save()
+    return HttpResponseRedirect(reverse('profile'))
+
+
+def hide_pamela(request):
+    request.user.hide_pamela = True
+    request.user.save()
+    return HttpResponseRedirect(reverse('profile'))
+
+
 class UserEditView(UpdateView):
     form_class = UserForm
     template_name = 'user_form.html'


### PR DESCRIPTION
* Ajout d'un champ `hide_pamela` (`True` par défaut) dans le modèle utilisateur. 
* Un utilisateur n'est dans la liste des gens sur Pamela que si `User.hide_pamela = False`
* Les personnes qui souhaitent cacher leur MAC sont toujours comptées dans le nombre de personnes présentes

![2015-12-11-201258_366x361_scrot](https://cloud.githubusercontent.com/assets/245617/11753315/b8eb3db6-a044-11e5-9cf5-ff6c3495d562.png)
