### PR TITLE
Event card enhancement 

### DIFF
--- a/events/templates/event_card.html
+++ b/events/templates/event_card.html
@@ -16,11 +16,14 @@
         </a>
       </div>
       <div class="col-xs-10">
-        <a href="#event-{{event.id}}-description" data-toggle="collapse">
           <h4>
-            {{ event.title }}
+            <a href="{% url "view_event" event.id %}">
+              {{ event.title }}
+            </a>
+            <a href="#event-{{event.id}}-description" data-toggle="collapse" class="collapsed">
+              <i class="fa fa-plus"></i>
+            </a>
           </h4>
-        </a>
       </div>
     </div>
   </div>

--- a/events/templates/event_card.html
+++ b/events/templates/event_card.html
@@ -20,7 +20,8 @@
             <a href="{% url "view_event" event.id %}">
               {{ event.title }}
             </a>
-            <a href="#event-{{event.id}}-description" data-toggle="collapse" class="collapsed">
+            <a href="#event-{{event.id}}-description" title="En savoir plus"
+               data-toggle="collapse" class="collapsed">
               <i class="fa fa-plus"></i>
             </a>
           </h4>

--- a/events/templates/event_card.html
+++ b/events/templates/event_card.html
@@ -1,7 +1,7 @@
 {% load formatting %}
 
 <div class="panel panel-default event-card">
-  <div class="panel-heading">    
+  <div class="panel-heading">
     <div class="row">
       <div class="col-xs-2">
         <a href="{% url "view_event" event.id %}">
@@ -11,7 +11,6 @@
                src="/static/img/default-event.png">
           {% else %}
             <img class="event-pic-thumb"
-               alt="Image manquante"
                src="{{event.picture.url}}">
           {% endif %}
         </a>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -78,6 +78,9 @@ body {
 .event-card .event-pic-thumb {
     border-radius: 50%;
     height: 3em;
+    width: 3em;
+    object-fit: cover; /* Do not scale the image */
+    object-position: center; /* Center the image within the element */
     transition: border-radius 0.5s;
 }
 .event-card:hover .event-pic-thumb {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -91,3 +91,7 @@ body {
     font-weight: bolder;
     text-align: right;
 }
+
+.event-card [data-toggle="collapse"]{
+  color: grey;
+}


### PR DESCRIPTION
![screenshot from 2016-02-06 18-24-55](https://cloud.githubusercontent.com/assets/85785/12868071/ff754650-ccfe-11e5-9e73-2ea3d93b84df.png)
 
* Images are now squared
* Event card title is now a link to the event and a "+" is now the button for expanding/collpsing the card