### PR TITLE
Force django-rest-framework to escape unicode

### DIFF
--- a/incubator/settings.py
+++ b/incubator/settings.py
@@ -162,6 +162,7 @@ MESSAGE_TAGS = {
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': ('incubator.drf.ReadOnlyPermission',),
     'DEFAULT_PAGINATION_CLASS': 'incubator.drf.AnachistPageNumberPagination',
+    'UNICODE_JSON': False,
 }
 
 # no tailing slash


### PR DESCRIPTION
Avant: `"Début du workshop"`
Après: `"D\u00e9but du workshop"`

Possiblement moins de problèmes d'encodage