### PR TITLE
Add stock handler endpoints

### DIFF
--- a/incubator/urls.py
+++ b/incubator/urls.py
@@ -16,6 +16,7 @@ urlpatterns = patterns(
     url(r'^projects/', include('projects.urls')),
     url(r'^accounts/', include('users.urls')),
     url(r'^space/', include('space.urls')),
+    url(r'^stock/', include('stock.urls')),
 
     url(r'^sm$', 'events.views.sm'),
     url(r'^linux$', 'events.views.linux'),

--- a/space/decorators.py
+++ b/space/decorators.py
@@ -15,6 +15,15 @@ def one_or_zero(arg):
     raise ValueError("not one or zero")
 
 
+def validate(cast, valid=lambda x: True):
+    def func(arg):
+        r = cast(arg)
+        if not valid(r):
+            raise ValueError("Invalid value")
+        return r
+    return func
+
+
 def private_api(**required_params):
     """
     Filter incoming private API requests, and perform parameter validation and

--- a/stock/migrations/0002_product_barcode.py
+++ b/stock/migrations/0002_product_barcode.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('stock', '0001_squashed_0002_auto_20151105_1555'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='product',
+            name='barcode',
+            field=models.TextField(default=''),
+        ),
+    ]

--- a/stock/models.py
+++ b/stock/models.py
@@ -12,3 +12,4 @@ class Product(models.Model):
     name = models.CharField(max_length=100)
     price = models.DecimalField(max_digits=6, decimal_places=2)
     category = models.ForeignKey(Category)
+    barcode = models.TextField(default="")

--- a/stock/tests/test_stock_handler.py
+++ b/stock/tests/test_stock_handler.py
@@ -3,9 +3,10 @@ from django.http.response import Http404
 from space.models import PrivateAPIKey
 from users.models import User
 from stock.models import Product, Category
-from stock.views import buy_product_with_stock_handler
+from stock.views import buy_product_with_stock_handler, product_infos
 
 import pytest
+import json
 
 
 def fib(n, x1=0, x2=1):
@@ -79,3 +80,13 @@ def test_zero_quantity(rf, secret):
                            'quantity': 0})
     response = buy_product_with_stock_handler(request)
     assert type(response) == HttpResponseBadRequest
+
+
+@pytest.mark.django_db
+def test_product_info(rf, secret):
+    request = rf.get('')
+    response = product_infos(request, PRODUCT_BARCODE)
+    data = json.loads(response.content.decode())
+    assert data['price'] == 4.2
+    assert data['name'] == 'product'
+    assert data['category'] == 'category'

--- a/stock/tests/test_stock_handler.py
+++ b/stock/tests/test_stock_handler.py
@@ -3,7 +3,7 @@ from django.http.response import Http404
 from space.models import PrivateAPIKey
 from users.models import User
 from stock.models import Product, Category
-from users.views import buy_product_with_stock_handler
+from stock.views import buy_product_with_stock_handler
 
 import pytest
 

--- a/stock/urls.py
+++ b/stock/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import patterns, url
+from .views import product_infos, buy_product_with_stock_handler
+
+urlpatterns = patterns(
+    '',
+    url(r'^product/(?P<product_barcode>.+)$', product_infos, name='product_infos'),
+    url(r'^stock_handler$', buy_product_with_stock_handler, name='stock_handler_endpoint'),
+)

--- a/stock/views.py
+++ b/stock/views.py
@@ -1,7 +1,12 @@
+from django.http import HttpResponse, JsonResponse
+from django.shortcuts import get_object_or_404
 from rest_framework import viewsets
+from actstream import action
 
 from .models import Product, Category
 from .serializers import ProductSerializer, CategorySerializer
+from space.decorators import private_api, validate
+from users.models import User
 
 
 class ProductViewSet(viewsets.ModelViewSet):
@@ -12,3 +17,26 @@ class ProductViewSet(viewsets.ModelViewSet):
 class CategoryViewSet(viewsets.ModelViewSet):
     queryset = Category.objects.all()
     serializer_class = CategorySerializer
+
+
+def product_infos(request, product_barcode):
+    prod = get_object_or_404(Product, barcode=product_barcode)
+    return JsonResponse({
+        'name': prod.name,
+        'category': prod.category.name,
+        'price': prod.price,
+    })
+
+
+@private_api(user_qrcode=str, product_barcode=str, quantity=validate(int, lambda x: x > 0))
+def buy_product_with_stock_handler(request, user_qrcode, product_barcode, quantity):
+    prod = get_object_or_404(Product, barcode=product_barcode)
+    user = get_object_or_404(User, qrcode=user_qrcode)
+    user.balance -= quantity * prod.price
+    user.save()
+    action.send(
+        user,
+        verb="a acheté {} pour {}€".format(prod.name, prod.price),
+        public=False
+    )
+    return HttpResponse("ok")

--- a/stock/views.py
+++ b/stock/views.py
@@ -24,7 +24,7 @@ def product_infos(request, product_barcode):
     return JsonResponse({
         'name': prod.name,
         'category': prod.category.name,
-        'price': prod.price,
+        'price': float(prod.price),
     })
 
 

--- a/users/migrations/0009_user_qrcode.py
+++ b/users/migrations/0009_user_qrcode.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0008_user_is_active'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='qrcode',
+            field=models.TextField(verbose_name='QR Code de la carte de membre', default=''),
+        ),
+    ]

--- a/users/models.py
+++ b/users/models.py
@@ -59,6 +59,7 @@ class User(AbstractBaseUser, PermissionsMixin):
     edited = models.DateTimeField(auto_now=True)
     first_name = models.CharField(max_length=127, blank=True)
     last_name = models.CharField(max_length=127, blank=True)
+    qrcode = models.TextField(default="", verbose_name='QR Code de la carte de membre')
 
     balance = models.DecimalField(max_digits=6, decimal_places=2, default=0, verbose_name="ardoise")
     has_key = models.BooleanField(default=False, verbose_name="possède une clé")

--- a/users/tests/test_stock_handler.py
+++ b/users/tests/test_stock_handler.py
@@ -1,4 +1,5 @@
 from django.http import HttpResponse, HttpResponseBadRequest
+from django.http.response import Http404
 from space.models import PrivateAPIKey
 from users.models import User
 from stock.models import Product, Category
@@ -38,6 +39,26 @@ def test_buy_product(rf, secret):
                            'quantity': 1})
     response = buy_product_with_stock_handler(request)
     assert type(response) == HttpResponse
+
+
+@pytest.mark.django_db
+def test_no_product(rf, secret):
+    request = rf.post('', {'secret': secret,
+                           'user_qrcode': USER_QR,
+                           'product_barcode': "007",
+                           'quantity': 1})
+    with pytest.raises(Http404):
+        buy_product_with_stock_handler(request)
+
+
+@pytest.mark.django_db
+def test_no_user(rf, secret):
+    request = rf.post('', {'secret': secret,
+                           'user_qrcode': "007",
+                           'product_barcode': PRODUCT_BARCODE,
+                           'quantity': 1})
+    with pytest.raises(Http404):
+        buy_product_with_stock_handler(request)
 
 
 @pytest.mark.django_db

--- a/users/tests/test_stock_handler.py
+++ b/users/tests/test_stock_handler.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseBadRequest
 from space.models import PrivateAPIKey
 from users.models import User
 from stock.models import Product, Category
@@ -31,10 +31,30 @@ def secret():
 
 
 @pytest.mark.django_db
-def test_buy_product_with_stock_handler(rf, secret):
+def test_buy_product(rf, secret):
     request = rf.post('', {'secret': secret,
                            'user_qrcode': USER_QR,
                            'product_barcode': PRODUCT_BARCODE,
                            'quantity': 1})
     response = buy_product_with_stock_handler(request)
     assert type(response) == HttpResponse
+
+
+@pytest.mark.django_db
+def test_negative_quantity(rf, secret):
+    request = rf.post('', {'secret': secret,
+                           'user_qrcode': USER_QR,
+                           'product_barcode': PRODUCT_BARCODE,
+                           'quantity': -1})
+    response = buy_product_with_stock_handler(request)
+    assert type(response) == HttpResponseBadRequest
+
+
+@pytest.mark.django_db
+def test_zero_quantity(rf, secret):
+    request = rf.post('', {'secret': secret,
+                           'user_qrcode': USER_QR,
+                           'product_barcode': PRODUCT_BARCODE,
+                           'quantity': 0})
+    response = buy_product_with_stock_handler(request)
+    assert type(response) == HttpResponseBadRequest

--- a/users/urls.py
+++ b/users/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, url
 from django.contrib.auth.decorators import login_required
 from .views import (
     balance, UserDetailView, UserEditView, spend, top, transfer, show_pamela,
-    hide_pamela, userdetail, product_infos, buy_product_with_stock_handler
+    hide_pamela, userdetail,
 )
 
 urlpatterns = patterns(
@@ -16,7 +16,4 @@ urlpatterns = patterns(
     url(r'^show_pamela$', login_required(show_pamela), name='show_pamela'),
     url(r'^hide_pamela$', login_required(hide_pamela), name='hide_pamela'),
     url(r'^(?P<slug>.+)$', UserDetailView.as_view(), name='user_profile'),
-
-    url(r'^product/(?P<product_barcode>.+)$', product_infos, name='product_infos'),
-    url(r'^stock_handler$', buy_product_with_stock_handler, name='stock_handler_endpoint'),
 )

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,9 @@
 from django.conf.urls import patterns, url
 from django.contrib.auth.decorators import login_required
-from .views import CurrentUserDetailView, balance, UserDetailView, UserEditView, spend, top, transfer, show_pamela, hide_pamela,userdetail
+from .views import (
+    balance, UserDetailView, UserEditView, spend, top, transfer, show_pamela,
+    hide_pamela, userdetail, product_infos, buy_product_with_stock_handler
+)
 
 urlpatterns = patterns(
     '',
@@ -13,4 +16,7 @@ urlpatterns = patterns(
     url(r'^show_pamela$', login_required(show_pamela), name='show_pamela'),
     url(r'^hide_pamela$', login_required(hide_pamela), name='hide_pamela'),
     url(r'^(?P<slug>.+)$', UserDetailView.as_view(), name='user_profile'),
+
+    url(r'^product/(?P<product_barcode>.+)$', product_infos, name='product_infos'),
+    url(r'^stock_handler$', buy_product_with_stock_handler, name='stock_handler_endpoint'),
 )

--- a/users/views.py
+++ b/users/views.py
@@ -32,10 +32,10 @@ def balance(request):
 
 
 @private_api(user_qrcode=str, product_barcode=str, quantity=int)
-def buy_product_with_stock_handler(request, user_qrcode, product_barcode):
+def buy_product_with_stock_handler(request, user_qrcode, product_barcode, quantity):
     prod = get_object_or_404(Product, barcode=product_barcode)
     user = get_object_or_404(User, qrcode=user_qrcode)
-    user.balance -= prod.price
+    user.balance -= quantity * prod.price
     user.save()
     action.send(
         user,

--- a/users/views.py
+++ b/users/views.py
@@ -7,6 +7,7 @@ from django.views.generic.detail import DetailView
 from django.views.generic import UpdateView
 from django.core.urlresolvers import reverse
 from django.contrib import messages
+from django.conf import settings
 from actstream import action
 from actstream.models import Action
 from space.djredis import get_redis

--- a/users/views.py
+++ b/users/views.py
@@ -1,8 +1,8 @@
 from rest_framework import viewsets
 # from django.core.urlresolvers import reverse
 # from django.http import HttpResponseRedirect
-from django.shortcuts import render, get_object_or_404
-from django.http import HttpResponseRedirect, JsonResponse
+from django.shortcuts import render
+from django.http import HttpResponseRedirect
 from django.views.generic.detail import DetailView
 from django.views.generic import UpdateView
 from django.core.urlresolvers import reverse

--- a/users/views.py
+++ b/users/views.py
@@ -2,16 +2,14 @@ from rest_framework import viewsets
 # from django.core.urlresolvers import reverse
 # from django.http import HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404
-from django.http import HttpResponseRedirect, JsonResponse, HttpResponse
+from django.http import HttpResponseRedirect, JsonResponse
 from django.views.generic.detail import DetailView
 from django.views.generic import UpdateView
 from django.core.urlresolvers import reverse
 from django.contrib import messages
-from django.conf import settings
 from actstream import action
 from actstream.models import Action
-from space.djredis import get_redis, space_is_open
-from space.decorators import private_api, validate
+from space.djredis import get_redis
 
 
 from .serializers import UserSerializer
@@ -28,32 +26,6 @@ def balance(request):
         'topForm': TopForm(),
         'spendForm': SpendForm(),
         'transferForm': TransferForm(),
-    })
-
-
-@private_api(user_qrcode=str, product_barcode=str, quantity=validate(int, lambda x: x > 0))
-def buy_product_with_stock_handler(request, user_qrcode, product_barcode, quantity):
-    if quantity <= 0:
-        return HttpResponseBadRequest("Only positive quantities")
-    prod = get_object_or_404(Product, barcode=product_barcode)
-    user = get_object_or_404(User, qrcode=user_qrcode)
-    user.balance -= quantity * prod.price
-    user.save()
-    action.send(
-        user,
-        verb="a acheté {} pour {}€".format(prod.name, prod.price),
-        public=False
-    )
-    return HttpResponse("ok")
-
-
-def product_infos(request, product_barcode):
-    # => {'price', 'name'}
-    prod = get_object_or_404(Product, barcode=product_barcode)
-    return JsonResponse({
-        'name': prod.name,
-        'category': prod.category.name,
-        'price': prod.price,
     })
 
 


### PR DESCRIPTION
- Ajout d'un point d'accès à l'API privée pour le stock handler, permettant de décompter une certaine quantité (positive) d'un article sur l'ardoise d'un membre. Nécessite d'ajouter les code-barres des produits vendus, ainsi que les QR code des cartes de membres dans la DB
- Ajout d'un point d'accès public permettant d'obtenir les infos sur un produit sur base de son code barres
