### PR TITLE
[fix] Get a fake openings dataframe when no records found

### DIFF
--- a/space/tests/test_openings.py
+++ b/space/tests/test_openings.py
@@ -1,0 +1,8 @@
+import pytest
+from space.views import get_openings_df
+
+
+@pytest.mark.django_db
+def test_openings_empty():
+    df = get_openings_df()
+    assert len(df) >= 2

--- a/space/views.py
+++ b/space/views.py
@@ -190,8 +190,16 @@ def get_openings_df(freq='H', **filter_args):
     # Grab openings in a pandas dataframe
     df = read_frame(SpaceStatus.objects.filter(**filter_args))
 
+    # No records found, just return a fake week, always closed
+    if len(df) == 0:
+        df = pd.DataFrame([
+            {'time': pd.datetime.now() - timedelta(days=7), 'is_open': 0},
+            {'time': pd.datetime.now(), 'is_open': 0}
+        ])
+
     # Drop duplicate time index
-    df = df[df.time.diff().dt.total_seconds() > 0]
+    delta_time = df.time.diff().dt.total_seconds()
+    df = df[np.isnan(delta_time) | (delta_time > 0)]
     df.index = df.time
 
     # Reindex on a monotonic hourly time index


### PR DESCRIPTION
Fix http://sentry.urlab.be/urlab/incubator/issues/357/events/