### PR TITLE
Ajout des tags OpenGraph

### DIFF
--- a/incubator/templates/base.html
+++ b/incubator/templates/base.html
@@ -7,9 +7,9 @@
 
 <!DOCTYPE html>
 <!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
-<html class="no-js" lang="en" >
+<html class="no-js" lang="en">
 
-<head>
+<head prefix="og: http://ogp.me/ns# place: http://ogp.me/ns/place# article: http://ogp.me/ns/article# fb: http://ogp.me/ns/fb#">
     {% analytical_head_top %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -25,7 +25,20 @@
         <link rel="icon" href="/static/img/favicon.ico"/>
         <title>{% block title %}UrLab{% endblock %}</title>
         {% block head %}{% endblock %}
-        {% analytical_head_bottom %}
+
+        {# Open Graph for Facebook integration http://ogp.me/ #}
+        <meta property="og:site_name" content="UrLab" />
+        <meta property="og:locale" content="fr_BE" />
+        <meta property="fb:app_id" content="1563249853970263" />
+        {% block opengraph %}
+            <meta property="og:title" content="UrLab" />
+            <meta property="og:type" content="place" />
+            <meta property="og:url" content="https://urlab.be" />
+            <meta property="og:image" content="https://urlab.be/static/img/space-invaders.png" />
+            <meta property="place:location:latitude" content="50.8129409" />
+            <meta property="place:location:longitude" content="4.3844292" />
+        {% endblock %}
+    {% analytical_head_bottom %}
     </head>
     <body class="base-body">
     {% analytical_body_top %}

--- a/projects/templates/project_detail.html
+++ b/projects/templates/project_detail.html
@@ -6,6 +6,22 @@
 {{project.title}}
 {% endblock %}
 
+{% block opengraph %}
+  <meta property="og:title" content="{{project.title}}" />
+  <meta property="og:description" content="{{project.short_description}}" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://urlab.be{% url "view_project" project.id %}" />
+  {% if project.picture %}
+    <meta property="og:image" content="https://urlab.be{{project.picture.url}}" />
+  {% else %}
+    <meta property="og:image" content="https://urlab.be/static/img/default-project.png" />
+  {% endif %}
+  <meta property="article:section" content="Projet" />
+  <meta property="article:author" content="{{project.maintainer.username}}" />
+  <meta property="article:published_time" content="{{project.created|date:"c"}}" />
+  <meta property="article:modified_time" content="{{project.modified|date:"c"}}" />
+{% endblock %}
+
 {% block content %}
 <style type="text/css">
 .project-detail-content img {


### PR DESCRIPTION
Intégration de tags sémantiques pour Facebook, permettant une meilleure intégration des pages de l'incubateur partagées sur le réseau social.

* Sur les pages des projets: référencement en tant qu'article avec courte description
* Sur toute autre page du site référencement du lieu 131 av. Buyl