### PR TITLE
[fix] All private_api endpoints should return JSON

### DIFF
--- a/events/views.py
+++ b/events/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect, HttpResponseForbidden, HttpResponse
+from django.http import HttpResponseRedirect, HttpResponseForbidden, HttpResponse, JsonResponse
 from django.views.generic.detail import DetailView
 from django.views.generic import CreateView, UpdateView
 from django.shortcuts import get_object_or_404
@@ -208,7 +208,8 @@ def add_point_to_next_meeting(request, point):
     meeting = get_next_meeting()
     meeting.OJ += '\n* ' + point
     meeting.save()
-    return HttpResponse("Point added to OJ")
+    r = {'new_point': point, 'full_oj': meeting.OJ}
+    return JsonResponse(r, safe=False)
 
 
 class NextMeetingAPI(APIView):

--- a/space/views.py
+++ b/space/views.py
@@ -84,13 +84,15 @@ def full_pamela(request):
 @private_api(open=one_or_zero)
 def status_change(request, open):
     set_space_open(get_redis(), open)
-    return HttpResponse("Hackerspace is now open={}".format(open))
+    r = {'open': open}
+    return JsonResponse(r, safe=False)
 
 
 @private_api(url=str, nick=str)
 def motd_change(request, url, nick):
     MusicOfTheDay.objects.create(url=url, irc_nick=nick)
-    return HttpResponse("Music has been changed to {} by {}".format(url, nick))
+    r = {'changed_by': nick, 'url': url}
+    return JsonResponse(r, safe=False)
 
 
 class DeleteMACView(DeleteView):


### PR DESCRIPTION
Since changes introduced in https://github.com/UrLab/lechbot/commit/e0a2c4a1d4c9f4b867a977fc4d3ab3a977e81a8f#diff-f376b640bbfb260ddd4c88ff52ed5909, we **absolutely** need to return JSON from private API endpoints