### PR TITLE
fixing requirements.txt again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,6 @@ django-jsonfield-compat
 pandas
 django-pandas
 pip>8.0
+django-picklefield==1.0.0
 django-constance[database]
  -e git://github.com/darklow/django-suit.git@v2#egg=django-suit


### PR DESCRIPTION
django-pickelfield was outputing errors while pip install -r requirements.txt.

Had to freeze it