### PR TITLE
Remove link to urlab.space,  add link to youtube channel

### DIFF
--- a/space/templates/map.html
+++ b/space/templates/map.html
@@ -29,19 +29,18 @@
             <i class="fa fa-github fa-stack-1x"></i>
         </span>
         </a>
+        <a href="https://www.youtube.com/UrLabBXL" title="Vidéos" target="_blank">
+        <span class="wow fa-stack fa-lg">
+            <i class="fa fa-square-o fa-stack-2x"></i>
+            <i class="fa fa-youtube fa-stack-1x"></i>
+        </span>
+        </a>
         <a href="http://urlab.be/events/urlab.ics" title="iCal" target="_blank">
         <span class="wow fa-stack fa-lg">
             <i class="fa fa-square-o fa-stack-2x"></i>
             <i class="fa fa-calendar fa-stack-1x"></i>
         </span>
         </a>
-        <a href="http://urlab.space" title="SpaceAPI" target="_blank">
-        <span class="wow fa-stack fa-lg">
-            <i class="fa fa-square-o fa-stack-2x"></i>
-            <i class="fa fa-space-shuttle fa-stack-1x"></i>
-        </span>
-        </a>
-
         <h3>Contact</h3>
         <h4>Mail
             <small>


### PR DESCRIPTION
Urlab.space has been domain squated

Add the youtube channel so people can watch the conf, and the number of icon remain constant