### PR TITLE
Automatically push the docker image to the github package #266

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,34 @@
+name: Run tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Lint python code
+        run: flake8 --ignore=E501,F401,E402,F811,E731,F403 .
+
+      - name: Run django checks
+        run: ./manage.py check
+
+      - name: Check migrations
+        run: ./manage.py makemigrations --dry-run --check
+
+      - name: Run tests
+        run: FAKE_REDIS=1 DEBUG=1 py.test

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,15 +1,12 @@
-name: Run tests
+name: build and push docker
 
 on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-20.04
 
     steps:
@@ -40,7 +37,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+        name: Set up Docker Buildx
 
-      - name: Build docker image
-        run: docker build -t urlab/incubator .
+      - uses: docker/build-push-action@v2
+        name: Build and push
+        with:
+          push: true
+          tags: docker.pkg.github.com/UrLab/incubator:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,12 @@ WORKDIR /srv
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-RUN apt update
-RUN apt install -y libpq-dev build-essential netcat
-
-RUN pip install --upgrade pip
+RUN apt update && apt install -y libpq-dev build-essential netcat && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements.txt .
-RUN pip install -r requirements.txt
-
 COPY ./requirements-prod.txt .
-RUN pip install -r requirements-prod.txt
+
+RUN pip install --upgrade pip && pip install -r requirements.txt && pip install -r requirements-prod.txt
 
 COPY . .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: '3.7'
 
 services:
   web:
-    build:
-      context: ./
-      dockerfile: Dockerfile
+    image: docker.pkg.github.com/UrLab/incubator:latest
     volumes:
       - static_volume:/srv/collected_static
       - media_volume:/srv/media


### PR DESCRIPTION
This merge request is for automatically push the latest docker image to the github package

Here a bref glance of the modification:

- Split github action to only build and push when there is a push on the main branch
- Rewritting the dockerfile in order to light up the docker image
- Pointing the github registry on the docker-compose