### PR TITLE
change default pad url

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -103,5 +103,5 @@ class Meeting(models.Model):
     def save(self, *args, **kwargs):
         super(Meeting, self).save(*args, **kwargs)
         if not self.pad:
-            self.pad = "https://pad.lqdn.fr/p/urlab-meeting-{}".format(self.id)
+            self.pad = "https://pad.lqdn.fr/p/urlab-meeting-notes-{}".format(self.id)
         super(Meeting, self).save(*args, **kwargs)


### PR DESCRIPTION
Pad have been pre-generated then archived by the provider so we currently have to manually edit the pad URL of each new meeting.

I solved that issue by changing the URL format.