### PR TITLE
[Fix] Show ants are gone along finished projects

### DIFF
--- a/projects/views.py
+++ b/projects/views.py
@@ -108,7 +108,18 @@ def projects_home(request):
 
     # group the finised and "ants are gone" projets together
     grouper = lambda x: x.status if x.status != "a" else "f"
-    groups = {k: list(g) for k, g in groupby(projects, grouper)}
+
+    # for an unknown reason, the following line does not work
+    # groups = {k: list(g) for k, g in groupby(projects, grouper)}
+    # Here a workaround
+    groups = groupby(projects, grouper)
+    groups = {}
+    for k, g in groups:
+        if k in groups:
+            groups[k].extend(list(g))
+        else:
+            groups[k] = list(g)
+
     context = {
         'progress': clusters_of(groups.get('i', []), 4),
         'done': clusters_of(groups.get('f', []), 4),


### PR DESCRIPTION
For some reason, the following lines
```py
grouper = lambda x: x.status if x.status != "a" else "f"
groups = {k: list(g) for k, g in groupby(projects, grouper)}
```

Do not work anymore, either all the projects have the "ants are gone" status and they are shown, or only the "finished" projects are shown.

A dirty workaround is to use the following lines instead:
```py
groups = groupby(projects, grouper)
groups = {}
for k, g in groups:
    if k in groups:
        groups[k].extend(list(g))
    else:
        groups[k] = list(g)
```