### PR TITLE
Interdiction des images en http dans les fields de markdown

### DIFF
--- a/events/forms.py
+++ b/events/forms.py
@@ -1,3 +1,4 @@
+import re
 from django.forms import ModelForm, Textarea
 
 from django import forms
@@ -22,6 +23,7 @@ class EventForm(ModelForm):
         start = cleaned_data.get("start")
         stop = cleaned_data.get("stop")
         status = cleaned_data.get("status")
+        content = cleaned_data.get("description")
 
         if start and stop:
             if stop < start:
@@ -35,6 +37,15 @@ class EventForm(ModelForm):
         if status == "r" and not start:
             raise forms.ValidationError(
                 "Un événement prêt doit avoir une date de début"
+            )
+
+        expr = re.compile(r"!\[.+\]\(http:\/\/.+\)")
+        matches = expr.findall(content)
+
+        if len(matches) > 0:
+            self.add_error(
+                "description",
+                f"La description de l'évènement contient des images en http non sécurisé ({' - '.join(matches)})"
             )
 
 

--- a/projects/forms.py
+++ b/projects/forms.py
@@ -1,4 +1,7 @@
+import re
+
 from django import forms
+from django.core.exceptions import ValidationError
 from .models import Project, Comment
 
 
@@ -10,6 +13,18 @@ class ProjectForm(forms.ModelForm):
         widgets = {
             'content': forms.Textarea(attrs={'rows': 25}),
         }
+
+    def clean(self):
+        cleaned_data = super().clean()
+        content = cleaned_data.get("content")
+        expr = re.compile(r"!\[.+\]\(http:\/\/.+\)")
+        matches = expr.findall(content)
+
+        if len(matches) > 0:
+            self.add_error(
+                "content",
+                f"The content of the article contains non https images ! ({' - '.join(matches)})"
+            )
 
 
 class CommentForm(forms.ModelForm):

--- a/projects/forms.py
+++ b/projects/forms.py
@@ -23,7 +23,7 @@ class ProjectForm(forms.ModelForm):
         if len(matches) > 0:
             self.add_error(
                 "content",
-                f"The content of the article contains non https images ! ({' - '.join(matches)})"
+                f"La description du projet contient des images en http non sécurisé ({' - '.join(matches)})"
             )
 
 
@@ -32,3 +32,15 @@ class CommentForm(forms.ModelForm):
         model = Comment
         fields = ['content', 'project', 'author']
         widgets = {'project': forms.HiddenInput(), 'author': forms.HiddenInput()}
+
+    def clean(self):
+        cleaned_data = super().clean()
+        content = cleaned_data.get("content")
+        expr = re.compile(r"!\[.+\]\(http:\/\/.+\)")
+        matches = expr.findall(content)
+
+        if len(matches) > 0:
+            self.add_error(
+                "content",
+                f"Le commentaire contient des images en http non sécurisé ({' - '.join(matches)})"
+            )

--- a/projects/views.py
+++ b/projects/views.py
@@ -197,6 +197,9 @@ def add_comment(request, project_id):
         form = CommentForm(request.POST)
         if form.is_valid():
             form.save()
+        else:
+            messages.error(request, form.errors)
+            return HttpResponseRedirect(reverse('view_project', args=[project_id]))
 
     project = get_object_or_404(Project, id=project_id)
     action.send(request.user, verb='a commenté sur le projet', action_object=project)

--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -12,3 +12,15 @@ class ArticleForm(ModelForm):
             'content': Textarea(attrs={'rows': 20}),
             'commit': Textarea(attrs={'rows': 3}),
         }
+
+    def clean(self):
+        cleaned_data = super().clean()
+        content = cleaned_data.get("content")
+        expr = re.compile(r"!\[.+\]\(http:\/\/.+\)")
+        matches = expr.findall(content)
+
+        if len(matches) > 0:
+            self.add_error(
+                "content",
+                f"L'article contient des images en http non sécurisé ({' - '.join(matches)})"
+            )

--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -1,3 +1,5 @@
+import re
+
 from django.forms import ModelForm, Textarea
 
 from .models import Article


### PR DESCRIPTION
Non https images are not allowed in the project creation/edit form :
![image](https://github.com/UrLab/incubator/assets/44365630/e0de7d82-c447-4a11-9dd0-f58667a4729c)

in the comments of the projects
![image](https://github.com/UrLab/incubator/assets/44365630/5038bd0e-3a88-4d35-8c1a-8e19046fa27d)

And in the wiki articles
![image](https://github.com/UrLab/incubator/assets/44365630/642caef8-98b9-4790-965b-44b594c15128)


Closes #157 