### PR TITLE
Putting the S on http for the ICS

### DIFF
--- a/space/templates/map.html
+++ b/space/templates/map.html
@@ -41,7 +41,7 @@
             <i class="fa fa-youtube fa-stack-1x"></i>
         </span>
         </a>
-        <a href="http://urlab.be/events/urlab.ics" title="iCal" target="_blank">
+        <a href="https://urlab.be/events/urlab.ics" title="iCal" target="_blank">
         <span class="wow fa-stack fa-lg">
             <i class="fa fa-square-o fa-stack-2x"></i>
             <i class="fa fa-calendar fa-stack-1x"></i>


### PR DESCRIPTION
When trying to add the ICS flow to my thunderbird, I noticed that thunderbird couldn't get through until I added the s to http. Just a quick little typo patch to fix the thing ;-)